### PR TITLE
EXTN-74: Better support for name and avatar

### DIFF
--- a/app/ada_api.py
+++ b/app/ada_api.py
@@ -23,7 +23,7 @@ def _colorize(status_code: int, text: str) -> str:
 
 
 async def send_user_message(
-    conversation_id: str, user_id: str, display_name: str, text: str
+    conversation_id: str, user_id: str, display_name: str, avatar: str, text: str
 ):
     """Send an end user message to Ada"""
 
@@ -37,7 +37,7 @@ async def send_user_message(
                     "role": "end_user",
                     "display_name": display_name,
                     "id": user_id,
-                    "avatar": "https://gravatar.com",
+                    "avatar": avatar,
                 },
                 "content": {"type": "text", "body": text},
             },
@@ -79,23 +79,6 @@ async def end_conversation(conversation_id: str):
         async with session.post(
             f"{ADA_BASE_URL}/api/v2/conversations/{conversation_id}/end",
             headers={"Authorization": f"Bearer {ADA_API_KEY}"},
-        ) as response:
-            body = await response.json()
-            print(_colorize(response.status, json.dumps(body)))
-
-            response.raise_for_status()
-
-
-async def update_user(end_user_id: str, first_name: str, last_name: str):
-    """Update an end user's display name"""
-
-    print("Updating end user...")
-
-    async with aiohttp.ClientSession() as session:
-        async with session.patch(
-            f"{ADA_BASE_URL}/api/v2/end-users/{end_user_id}",
-            headers={"Authorization": f"Bearer {ADA_API_KEY}"},
-            json={"profile": {"first_name": first_name, "last_name": last_name}},
         ) as response:
             body = await response.json()
             print(_colorize(response.status, json.dumps(body)))

--- a/app/server/webhooks.py
+++ b/app/server/webhooks.py
@@ -112,10 +112,12 @@ async def batch_process_messages():
             msg.data.author.role,
             msg.data.content.type,
             msg.data.content.body,
+            msg.data.author.display_name,
+            msg.data.author.avatar,
         )
 
 
-def push_message_to_chat(conversation_id: str, user_id: str | None, role: str, msg_type: str, text: str):
+def push_message_to_chat(conversation_id: str, user_id: str | None, role: str, msg_type: str, text: str, display_name: str | None = None, avatar: str | None = None):
     """Convert a message from Ada's webhook to one that is displayed in the chat UI"""
 
     chat_ui = get_chat_ui(conversation_id)
@@ -123,6 +125,6 @@ def push_message_to_chat(conversation_id: str, user_id: str | None, role: str, m
         return
 
     if msg_type == "text":
-        chat_ui.add_message(user_id, role, text)
+        chat_ui.add_message(user_id, role, text, display_name, avatar)
     elif msg_type == "presence":
         chat_ui.send_notification(text)

--- a/app/webpage/chat_ui.py
+++ b/app/webpage/chat_ui.py
@@ -8,15 +8,18 @@ class Message:
     text: str
     user_id: str | None = None
     name: str | None = None
+    avatar: str | None = None
 
     @property
     def display_name(self):
-        if self.role == "ada_ai_agent":
-            return "AI Agent"
+        if self.role == "ai_agent":
+            default_name = "AI Agent"
         elif self.role == "human_agent":
-            return "Human Agent"
+            default_name = "Human Agent"
         else:
-            return f"{self.name or "End User"} ({self.user_id or self.role})"
+            default_name = "End User"
+
+        return f"{self.name or default_name} ({self.user_id or self.role})"
 
 
 @dataclass
@@ -39,12 +42,12 @@ class ChatUI:
         with ui.scroll_area().classes("flex-1") as chat_scroll:
             with ui.column().classes("w-full items-stretch"):
                 for m in self._messages:
-                    ui.chat_message(text=m.text, sent=(m.user_id == self.active_end_user_id), name=m.display_name)
+                    ui.chat_message(text=m.text, sent=(m.user_id == self.active_end_user_id), name=m.display_name, avatar=m.avatar)
 
         chat_scroll.scroll_to(percent=100)
 
-    def add_message(self, user_id: str | None, role: str, text: str, name: str | None = None):
-        self._messages.append(Message(role, text, user_id, name))
+    def add_message(self, user_id: str | None, role: str, text: str, name: str | None = None, avatar: str | None = None):
+        self._messages.append(Message(role, text, user_id, name, avatar))
         self.message_list_element.refresh()
 
     def send_notification(self, text: str):

--- a/app/webpage/index.py
+++ b/app/webpage/index.py
@@ -20,7 +20,7 @@ async def index():
         text_value = text_input.value
         chat_ui.add_message(user_id, "end_user", text_value, display_name)
         text_input.value = ""
-        await ada_api.send_user_message(conversation_id, user_id, display_name, text_value)
+        await ada_api.send_user_message(conversation_id, user_id, display_name, avatar, text_value)
 
     async def _end_chat():
         text_input.value = ""
@@ -35,6 +35,7 @@ async def index():
 
     user_id = app.storage.user.get("end_user_id")
     display_name = app.storage.user.get("display_name", _generate_name())
+    avatar = "https://upload.wikimedia.org/wikipedia/commons/0/09/.hecko_-_Floaty_-_profile_picture.svg"
 
     user_id, conversation_id = await ada_api.start_new_conversation(user_id)
 
@@ -56,5 +57,3 @@ async def index():
         )
         end_button = ui.button("End Chat", on_click=_end_chat, color="red", icon="exit_to_app")
         ui.button("Reset", on_click=_reset, color="blue", icon="refresh")
-
-    await ada_api.update_user(user_id, *display_name.split())

--- a/app/webpage/index.py
+++ b/app/webpage/index.py
@@ -18,7 +18,7 @@ def _generate_name() -> str:
 async def index():
     async def _send():
         text_value = text_input.value
-        chat_ui.add_message(user_id, "end_user", text_value, display_name)
+        chat_ui.add_message(user_id, "end_user", text_value, display_name, avatar)
         text_input.value = ""
         await ada_api.send_user_message(conversation_id, user_id, display_name, avatar, text_value)
 


### PR DESCRIPTION
I noticed some minor issues / improvements we could make to the example, so I'm just adding them here. Mainly that we're actually showing avatars and display_names from the webhooks now, and that we're no longer relying on the End Users API for the implementation, since the `author` field for messages is meant to fix that gap.