### PR TITLE
EXTN-238: Include channel object in conversation.message webhook event payload

### DIFF
--- a/app/server/webhooks.py
+++ b/app/server/webhooks.py
@@ -24,7 +24,7 @@ class PostMessageAuthor(BaseModel):
 
 class PostMessageChannel(BaseModel):
     id: str
-    type: str | None
+    type: str
     name: str
     description: str
     modality: str
@@ -35,7 +35,6 @@ class PostMessageChannel(BaseModel):
 class PostMessageData(BaseModel):
     message_id: str
     conversation_id: str
-    channel_id: str
     channel: PostMessageChannel
     created_at: datetime
     author: PostMessageAuthor


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4d42850c-7c40-4659-8ff9-bf7c57db071f)

Adds a `PostMessageChannel` model for better logging
